### PR TITLE
Update KIE website header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -32,6 +32,7 @@
   <div class="wrapper">
     <div class="logo"></div>
     <h1>KIE</h1>
+    <a href="http://blog.kie.org">Blog</a>
     <a href="https://kogito.kie.org">Kogito</a>
     <a href="http://www.drools.org">Drools</a>
     <a href="http://www.jbpm.org/">jBPM</a>
@@ -39,6 +40,7 @@
     <a href="#" id="responsive_menu_button">&#9776;</a>
     <a href="#" id="middleware_tab_button"></a>
     <ul id=responsive_menu>
+      <li><a href="http://blog.kie.org">Blog</a></li>
       <li><a href="https://kogito.kie.org">Kogito</a></li>
       <li><a href="http://www.drools.org">Drools</a></li>
       <li><a href="http://www.jbpm.org/">jBPM</a></li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,3 +1,5 @@
+<div id="overlay"></div>
+
 <nav id="kie_header">
   <div class="wrapper">
     <div class="logo"></div>
@@ -7,20 +9,58 @@
     <a href="http://www.drools.org">Drools</a>
     <a href="http://www.jbpm.org/">jBPM</a>
     <a href="http://www.optaplanner.org">Optaplanner</a>
-    <a href="#" id="responsive_menu_button">&#9776;</a>
-    <ul id=responsive_menu>
-      <li><a href="http://blog.kie.org">Blog</a></li>
-      <li><a href="https://kogito.kie.org">Kogito</a></li>
-      <li><a href="http://www.drools.org">Drools</a></li>
-      <li><a href="http://www.jbpm.org/">jBPM</a></li>
-      <li><a href="http://www.optaplanner.org">Optaplanner</a></li>
-    </ul>
+    <a href="#" class="responsive-menu-button">&#9776;</a>
   </div>
 </nav>
 
+<div id="responsive_menu">
+  <ul>
+    <li>
+      <a href="#" class="responsive-menu-button close-button">&#10005;</a>
+      <h4>
+        KIE websites
+      </h4>
+      <ul>
+        <li><a href="http://blog.kie.org">Blog</a></li>
+        <li><a href="https://kogito.kie.org">Kogito</a></li>
+        <li><a href="http://www.drools.org">Drools</a></li>
+        <li><a href="http://www.jbpm.org/">jBPM</a></li>
+        <li><a href="http://www.optaplanner.org">Optaplanner</a></li>
+      </ul>
+    </li>
+  </ul>
+</div>
+
 <script type="text/javascript">
-  $("#responsive_menu_button").click(function() {
-    $("#kie_header").toggleClass("responsive-menu-opened");
-    return false;
-  });
+  (function() {
+
+    var responsiveMenuClass = "responsive-menu-opened";
+
+    function closeResponsiveMenu() {
+      document.body.classList.remove(responsiveMenuClass);
+    }
+
+    function toggleResponsiveMenu() {
+      document.body.classList.toggle(responsiveMenuClass);
+    }
+
+    $(".responsive-menu-button").click(function(e) {
+      toggleResponsiveMenu();
+      e.preventDefault();
+      return false;
+    });
+
+    $(document).keyup(function(e) {
+      if (e.keyCode === 27) {
+        closeResponsiveMenu()
+      }
+    });
+
+    $(document).click(closeResponsiveMenu);
+
+    // Do not hide sidebar when click event happens inside of responsive menu.
+    $('#responsive_menu').click(function(event) {
+      event.stopPropagation();
+    });
+  }())
 </script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,33 +1,3 @@
-<div id="middleware_tab">
-  <div class="wrapper">
-    <p>
-      Like <b>KIE</b>? Learn more about Red Hat and our open source communities:
-    </p>
-    
-    <div class="row">
-      <div class="column middleware-logo">
-        <img src="//static.jboss.org/common/images/tabzilla/RHJB_Middleware_Logotype.png" alt="Red Hat JBoss MIDDLEWARE">
-      </div>
-      
-      <div class="column">
-        <ul>
-          <li><a href="http://www.jboss.org/technology">Red Hat JBoss Middleware Overview</a></li>
-          <li><a href="http://www.jboss.org/products/">Red Hat JBoss Middleware Products</a></li>
-          <li><a href="http://www.jboss.org/projects/">Red Hat JBoss Projects &amp; Standards</a></li>
-        </ul>
-      </div>
-      
-      <div class="column">
-        <ul>
-          <li><a href="http://www.redhat.com/">redhat.com</a></li>
-          <li><a href="http://access.redhat.com/">Red Hat Customer Portal</a></li>
-          <li><a href="http://www.openshift.com/">OpenShift</a></li>
-        </ul>
-      </div>
-    </div>
-  </div>
-</div>
-
 <nav id="kie_header">
   <div class="wrapper">
     <div class="logo"></div>
@@ -38,7 +8,6 @@
     <a href="http://www.jbpm.org/">jBPM</a>
     <a href="http://www.optaplanner.org">Optaplanner</a>
     <a href="#" id="responsive_menu_button">&#9776;</a>
-    <a href="#" id="middleware_tab_button"></a>
     <ul id=responsive_menu>
       <li><a href="http://blog.kie.org">Blog</a></li>
       <li><a href="https://kogito.kie.org">Kogito</a></li>
@@ -50,10 +19,6 @@
 </nav>
 
 <script type="text/javascript">
-  $("#middleware_tab_button").click(function() {
-    $("#middleware_tab").toggleClass("opened");
-    return false;
-  });
   $("#responsive_menu_button").click(function() {
     $("#kie_header").toggleClass("responsive-menu-opened");
     return false;

--- a/_sass/_Header.sass
+++ b/_sass/_Header.sass
@@ -52,23 +52,6 @@ nav
     display: none
     float: right
 
-  #middleware_tab_button
-    position: relative
-    float: right
-    background: url(http://static.jboss.org/images/tabzilla/tabzilla-redhat-logo-sprite.png) no-repeat
-    width: 113px
-    height: 37px
-
-    &:after
-      background: url(http://static.jboss.org/common/images/arrow-tabnav-down.png) no-repeat
-      transition: all 0.2s ease-in-out
-      content: ""
-      position: absolute
-      height: 15px
-      right: 17px
-      top: 9px
-      width: 13px
-
   @media (max-width: 60.0rem)
     a
       display: none
@@ -76,7 +59,6 @@ nav
     h1
       border-right: none
 
-    #middleware_tab_button,
     #responsive_menu_button
       display: block
 
@@ -95,49 +77,3 @@ nav
           margin-bottom: 0
           a
             display: block
-
-
-  @media (max-width: 30.0rem)
-    #middleware_tab_button
-      display: none
-
-#middleware_tab
-  background: linear-gradient(to bottom,#e1eef4 0,#fff 60%) no-repeat scroll 0 0 transparent
-  transition: height .75s cubic-bezier(0.58, 0.15, 0.51, 0.89)
-  box-shadow: inset 0 -5px 15px 0 rgba(0,0,0, 0.1)
-  height: 0
-  overflow: hidden
-
-  .middleware-logo
-    img
-      padding: 1.5rem 7rem 3rem 0
-      border-right: 1px solid #DDD
-
-  ul
-    list-style: none
-
-    li
-      margin: 0
-
-  a
-    color: #369
-    text-decoration: none
-    text-shadow: 0 1px 1px #e4eaf1
-    font-size: 1.5rem
-
-#middleware_tab.opened
-  height: 210px
-
-#middleware_tab.opened + #kie_header
-  #middleware_tab_button:after
-    transform: rotate(180deg)
-
-@media (max-width: 40.0rem)
-  #middleware_tab.opened
-    height: 475px
-    img
-      padding: 1.5rem 3rem 3rem
-      margin-bottom: 3rem
-      border-right: none
-      border-bottom: 1px solid #DDD
-

--- a/_sass/_Header.sass
+++ b/_sass/_Header.sass
@@ -27,8 +27,9 @@ nav
     font-weight: 800
     color: $color-secondary
     text-transform: uppercase
-    line-height: 6.5rem
+    line-height: 6.8rem
     padding: 0.2rem 2rem
+    height: 70px
 
   a:hover
     background-color: #DDD
@@ -45,35 +46,78 @@ nav
     margin: 5px 30px 0 0
     border-bottom: 2px solid #DDD
 
-  ul
-    display:  none
-
-  #responsive_menu_button
+  .responsive-menu-button
+    position: absolute
+    right: 0
     display: none
-    float: right
 
-  @media (max-width: 60.0rem)
+#overlay
+  position: fixed
+  width: 100vw
+  height: 100vh
+  background-color: rgba(0, 0, 0, 0.5)
+  z-index: 2
+  pointer-events: none
+  opacity: 0
+  transition: opacity 0.1s
+
+#responsive_menu
+  width: 300px
+  height: 100vh
+  background: rgba(255, 255, 255, 0.9)
+  position: fixed
+  z-index: 3
+  top: 0
+  right: -320px
+  box-shadow: 0 0 20px 0px rgba(0, 0, 0, 0.2)
+  border-left: 2px solid #5f5f5f
+  padding: 10px 20px 0 20px
+  transition: right 0.5s
+  transform: rotate3d(0, 0, 0, 0deg)
+  .close-button
+    display: block
+    width: 100%
+    text-align: right
+  .close-button + h4
+    margin-top: 10px
+    outline: none
+  ul
+    padding: 0
+    margin: 0
+    list-style: none
+    ul
+      padding-left: 2.5rem
+    li
+      margin: 0
+      padding: 5px 0
+  h4,
+  li a
+    color: #475058
+    font-family: "Overpass", sans-serif
+  li a
+    font-size: 16px
+    font-weight: 700
+  h4
+    font-size: 1.8rem
+    margin: 20px 0 7px
+    font-weight: 800
+    border-bottom: 1px solid #d1d7dc
+    padding-bottom: 15px
+
+.responsive-menu-opened
+  overflow: hidden
+  nav,
+  main
+    filter: blur(1px)
+  #overlay
+    opacity: 1
+  #responsive_menu
+    right: 0
+
+
+@media (max-width: 900px)
+  nav
     a
       display: none
-
-    h1
-      border-right: none
-
-    #responsive_menu_button
-      display: block
-
-    &.responsive-menu-opened
-      height: 37.5rem
-
-      ul
-        display: block
-        list-style: none
-        padding: 0
-        background: #e8e8e8
-        margin-top: -1rem
-        text-align: right
-        li
-          border-bottom: 1px solid #FFF
-          margin-bottom: 0
-          a
-            display: block
+    .responsive-menu-button
+      display: inline-block


### PR DESCRIPTION
This PR:
- Removes the Red Hat logo from the top-right corner
- Adds the "Blog" menu item
- Adds the new sidebar for small screens

Demo:

<img width="956" alt="Screen Shot 2020-05-20 at 16 47 02" src="https://user-images.githubusercontent.com/1079279/82490782-1e3b0380-9aba-11ea-8024-fb1a6f17cdec.png">

![2020-05-20 16 46 32](https://user-images.githubusercontent.com/1079279/82490759-19764f80-9aba-11ea-94f9-fd875306d73f.gif)
